### PR TITLE
Add guest management service

### DIFF
--- a/local-playbooks/roles/setup-ocp-deployer/tasks/main.yml
+++ b/local-playbooks/roles/setup-ocp-deployer/tasks/main.yml
@@ -171,6 +171,34 @@
       state: stopped
       enabled: no
 
+- name: set up ocp-cluster-guests script and start/stop services
+  block:
+  - name: copy the action script
+    template:
+      src: ocp-cluster-guests.sh.j2
+      dest: /usr/local/bin/ocp-cluster-guests.sh
+      mode: 0750
+  - name: copy the ocp-guests-start systemd service file
+    template:
+      src: ocp-guests-start.service.j2
+      dest: /etc/systemd/system/ocp-guests-start.service
+      mode: 0644
+  - name: copy the ocp-guests-stop systemd service file
+    template:
+      src: ocp-guests-stop.service.j2
+      dest: /etc/systemd/system/ocp-guests-stop.service
+      mode: 0644
+  - name: Do not enable the ocp-guests-start service
+    systemd:
+      name: ocp-guests-start
+      state: stopped
+      enabled: no
+  - name: Do not enable the ocp-guests-stop service
+    systemd:
+      name: ocp-guests-stop
+      state: stopped
+      enabled: no
+
 - name: set up the kick-off-the-build incron stuff
   block:
   - name: copy the kicker script

--- a/local-playbooks/roles/setup-ocp-deployer/templates/create-cluster-main.yml.j2
+++ b/local-playbooks/roles/setup-ocp-deployer/templates/create-cluster-main.yml.j2
@@ -246,6 +246,9 @@
     name: ocp-approve-csrs
     state: stopped
 
+- name: shut down the bootstrap node # noqa 301
+  shell: smcli id -T {{ cluster_nodes['bootstrap']['bootstrap-0'].guest_name }} -t 'WITHIN 60' -H {{ ocp_smapi_host }} -U {{ ocp_smapi_user }} -P '{{ ocp_smapi_password }}'
+
 - name: update boot device on the master nodes
   include_tasks: guest-IPLdev.yml
   vars:
@@ -261,3 +264,9 @@
 
 - name: configure the cluster (LDAP, ingress certificate)
   include_tasks: configure-cluster.yml
+
+- name: enable the start-the-guests service
+  systemd:
+    name: ocp-cluster-guests
+    state: stopped
+    enabled: yes

--- a/local-playbooks/roles/setup-ocp-deployer/templates/create-cluster-main.yml.j2
+++ b/local-playbooks/roles/setup-ocp-deployer/templates/create-cluster-main.yml.j2
@@ -267,6 +267,6 @@
 
 - name: enable the start-the-guests service
   systemd:
-    name: ocp-cluster-guests
+    name: ocp-guests-start
     state: stopped
     enabled: yes

--- a/local-playbooks/roles/setup-ocp-deployer/templates/ocp-cluster-guests.service.j2
+++ b/local-playbooks/roles/setup-ocp-deployer/templates/ocp-cluster-guests.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=Start or stop the guests of our OCP cluster
+Wants=network.target network-online.target
+After=network.target network-online.target
+
+[Service]
+User=root
+Group=root
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/bin/ocp-cluster-guests.sh start
+ExecStop=/usr/local/bin/ocp-cluster-guests.sh stop
+
+[Install]
+WantedBy=multi-user.target

--- a/local-playbooks/roles/setup-ocp-deployer/templates/ocp-cluster-guests.sh.j2
+++ b/local-playbooks/roles/setup-ocp-deployer/templates/ocp-cluster-guests.sh.j2
@@ -3,14 +3,24 @@
 # ocp-cluster-guests.sh
 # Start or stop the OCP guests
 # - Script is deployed by Ansible
-# - Run when required to prepare for another build attempt
+# - Invoke using systemctl services for better locking!
 #
 
 mode=$1
-if [ -z ${mode} ]; then
-  echo "Run mode not entered: must enter 'start' or 'stop'"
-  exit 1
-fi
+case "${mode}" in
+  "start")
+    operands="ia -T ${guest}"
+    othersvc="stop"
+    ;;
+  "stop")
+    operands="id -T ${guest} -t 'WITHIN 60'"
+    othersvc="start"
+    ;;
+  *)
+    echo "Run mode bad or missing: must be 'start' or 'stop'"
+    exit 1
+    ;;
+esac
 
 # pause until SMAPI is active, then a little more
 until vmcp Q VSMREQIN >/dev/null 2>&1 ; do
@@ -26,12 +36,8 @@ allguests="{{ guestnames }}"
 ocpguests=${allguests//{{ cluster_nodes['bootstrap']['bootstrap-0'].guest_name }}}
 IFS=" "
 
-case "${mode}" in
-  "start" ) operands="ia -T ${guest}"
-    ;;
-  "stop" ) operands="id -T ${guest} -t 'WITHIN 60'"
-    ;;
-esac
+# Mask the other service
+systemctl mask ocp-guests-${othersvc}.service
 
 # Do this for each guest:
 for guest in ${ocpguests} ; do
@@ -41,7 +47,7 @@ for guest in ${ocpguests} ; do
   sleep 2
 done
 
-if [ "${mode}" eq "stop" ]; then
+if [ "${mode}" == "stop" ]; then
   # give some time to make sure the guests are down
   sleep 10
   # Do this for each guest:
@@ -52,3 +58,6 @@ if [ "${mode}" eq "stop" ]; then
     echo "${guest} is down"
   done
 fi
+
+# Unmask the other service
+systemctl unmask ocp-guests-${othersvc}.service

--- a/local-playbooks/roles/setup-ocp-deployer/templates/ocp-cluster-guests.sh.j2
+++ b/local-playbooks/roles/setup-ocp-deployer/templates/ocp-cluster-guests.sh.j2
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# ocp-cluster-guests.sh
+# Start or stop the OCP guests
+# - Script is deployed by Ansible
+# - Run when required to prepare for another build attempt
+#
+
+mode=$1
+if [ -z ${mode} ]; then
+  echo "Run mode not entered: must enter 'start' or 'stop'"
+  exit 1
+fi
+
+# pause until SMAPI is active, then a little more
+until vmcp Q VSMREQIN >/dev/null 2>&1 ; do
+  echo "Pausing to wait for SMAPI listener"
+  sleep 10
+done
+echo "SMAPI listener active, continuing..."
+sleep 3
+
+# Obtain the list of guests
+allguests="{{ guestnames }}"
+# Drop the bootstrap guest from the list
+ocpguests=${allguests//{{ cluster_nodes['bootstrap']['bootstrap-0'].guest_name }}}
+IFS=" "
+
+case "${mode}" in
+  "start" ) operands="ia -T ${guest}"
+    ;;
+  "stop" ) operands="id -T ${guest} -t 'WITHIN 60'"
+    ;;
+esac
+
+# Do this for each guest:
+for guest in ${ocpguests} ; do
+  # Act on the guest
+  smcli ${operands} -H {{ ocp_smapi_host }} -U {{ ocp_smapi_user }} -P '{{ ocp_smapi_password }}'
+  # Nap a moment
+  sleep 2
+done
+
+if [ "${mode}" eq "stop" ]; then
+  # give some time to make sure the guests are down
+  sleep 10
+  # Do this for each guest:
+  for guest in ${ocpguests} ; do
+    while vmcp q ${guest} >/dev/null 2>&1 ; do
+      sleep 1
+    done
+    echo "${guest} is down"
+  done
+fi

--- a/local-playbooks/roles/setup-ocp-deployer/templates/ocp-guests-start.service.j2
+++ b/local-playbooks/roles/setup-ocp-deployer/templates/ocp-guests-start.service.j2
@@ -1,5 +1,5 @@
 [Unit]
-Description=Start or stop the guests of our OCP cluster
+Description=Start the guests of our OCP cluster
 Wants=network.target network-online.target
 After=network.target network-online.target
 
@@ -7,9 +7,7 @@ After=network.target network-online.target
 User=root
 Group=root
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/local/bin/ocp-cluster-guests.sh start
-ExecStop=/usr/local/bin/ocp-cluster-guests.sh stop
 
 [Install]
 WantedBy=multi-user.target

--- a/local-playbooks/roles/setup-ocp-deployer/templates/ocp-guests-stop.service.j2
+++ b/local-playbooks/roles/setup-ocp-deployer/templates/ocp-guests-stop.service.j2
@@ -1,0 +1,13 @@
+[Unit]
+Description=Stop the guests of our OCP cluster
+Wants=network.target network-online.target
+After=network.target network-online.target
+
+[Service]
+User=root
+Group=root
+Type=oneshot
+ExecStart=/usr/local/bin/ocp-cluster-guests.sh stop
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
A service to manage OCP cluster guest startup and shutdown.

Tracked in #50.