### PR TITLE
Implement interCA differentiation (fix #56)

### DIFF
--- a/local-playbooks/roles/copy-ca-to-bastion/tasks/main.yml
+++ b/local-playbooks/roles/copy-ca-to-bastion/tasks/main.yml
@@ -4,9 +4,9 @@
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
   loop:
-    - { src: "{{ root_ca_key_path }}/oqsCA.pem", dest: "{{ ca_key_path }}/" }
-    - { src: "{{ root_ca_csr_path }}/oqsCA.csr", dest: "{{ ca_csr_path }}/" }
-    - { src: "{{ root_ca_cert_path }}/oqsCA.cert", dest: "{{ ca_cert_path }}/" }
+    - { src: "{{ root_ca_key_path }}/oqsCA-{{ cluster_domain_name }}.pem", dest: "{{ ca_key_path }}/oqsCA.pem" }
+    - { src: "{{ root_ca_csr_path }}/oqsCA-{{ cluster_domain_name }}.csr", dest: "{{ ca_csr_path }}/oqsCA.csr" }
+    - { src: "{{ root_ca_cert_path }}/oqsCA-{{ cluster_domain_name }}.cert", dest: "{{ ca_cert_path }}/oqsCA.cert" }
     - { src: "{{ root_ca_cert_path }}/oqsRootCA.cert", dest: "{{ ca_cert_path }}/" }
 
 - name: add the root certs to the trust store

--- a/local-playbooks/roles/create-local-ca/tasks/main.yml
+++ b/local-playbooks/roles/create-local-ca/tasks/main.yml
@@ -1,15 +1,15 @@
 ---
 - name: generate CA private key
   openssl_privatekey:
-    path: "{{ ca_key_path }}/oqsCA.pem"
+    path: "{{ ca_key_path }}/oqsCA-{{ cluster_domain_name }}.pem"
     group: support
     mode: 0640
 
 - name: generate CA CSR
   openssl_csr:
-    path: "{{ ca_csr_path }}/oqsCA.csr"
-    privatekey_path: "{{ ca_key_path }}/oqsCA.pem"
-    common_name: "{{ cluster_name }}.{{ cluster_base_domain }}"
+    path: "{{ ca_csr_path }}/oqsCA-{{ cluster_domain_name }}.csr"
+    privatekey_path: "{{ ca_key_path }}/oqsCA-{{ cluster_domain_name }}.pem"
+    common_name: "{{ cluster_domain_name }}"
     organization_name: "{{ cert_organization }}"
     organizational_unit_name: "IBM LinuxONE PoC"
     country_name: "{{ cert_country }}"
@@ -18,16 +18,16 @@
 
 - name: generate CA Certificate
   openssl_certificate:
-    path: "{{ ca_cert_path }}/oqsCA.cert"
-    csr_path: "{{ ca_csr_path }}/oqsCA.csr"
+    path: "{{ ca_cert_path }}/oqsCA-{{ cluster_domain_name }}.cert"
+    csr_path: "{{ ca_csr_path }}/oqsCA-{{ cluster_domain_name }}.csr"
     ownca_path: "{{ ca_cert_path }}/oqsRootCA.cert"
     ownca_privatekey_path: "{{ ca_key_path }}/oqsRootCA.pem"
     provider: ownca
 
 - name: add CA certificate to the local trust store
   file:
-    src: "{{ ca_cert_path }}/oqsCA.cert"
-    dest: "{{ ca_trust_path }}/oqsCA.cert"
+    src: "{{ ca_cert_path }}/oqsCA-{{ cluster_domain_name }}.cert"
+    dest: "{{ ca_trust_path }}/oqsCA-{{ cluster_domain_name }}.cert"
     state: link
 #  notify:
 #    - update ca trust


### PR DESCRIPTION
Tested in the deployment on SYDVM10, this update moves to creating separate intermediate CA certificates for different domain names (if known in the Ansible inventory).