### PR TITLE
Fixes for #92

### DIFF
--- a/local-playbooks/roles/setup-icic-deployer/templates/icic-setup.sh.j2
+++ b/local-playbooks/roles/setup-icic-deployer/templates/icic-setup.sh.j2
@@ -95,6 +95,11 @@ growguest() {
     # grab an available space
     IFS=" " read -r -a dasd <<< ${dasds[$((dasdnum++))]}
     IFS=" " avail=${dasd[3]}
+    # if there is no more DASD, avail will not be a number
+    if [ ! -z "${avail}//[0-9]" ]; then
+      echo "No DASD volume available, we are ${SPACE} too short"
+      break
+    fi
     if [ "${avail}" -ge "${SPACE}" ]; then
       # This disk has more free space than we need, just grab it
       alloc=${SPACE}
@@ -116,7 +121,13 @@ until vmcp Q VSMREQIN 2>/dev/null ; do
   sleep 10
 done
 sleep 3
-echo "SMAPI listener active, continuing..."
+smcli qafl -T IBMAUTO ${smapiauth}
+if [ $? -ne 0 ]; then
+  echo "SMAPI is not operating, cannot continue"
+  exit 5
+else
+  echo "SMAPI listener active, continuing..."
+fi
 
 # fetch our current IP address, and strip the netmask off the end
 myip=$(ip -br addr show dev encad0 | awk '{print $3}') # the devname in here has to be set using Ansible too

--- a/local-playbooks/roles/setup-ocp-deployer/templates/ocp-cluster-guests.sh.j2
+++ b/local-playbooks/roles/setup-ocp-deployer/templates/ocp-cluster-guests.sh.j2
@@ -22,13 +22,21 @@ case "${mode}" in
     ;;
 esac
 
+smapiauth='-H {{ ocp_smapi_host }} -U {{ ocp_smapi_user }} -P {{ ocp_smapi_password }}'
+
 # pause until SMAPI is active, then a little more
 until vmcp Q VSMREQIN >/dev/null 2>&1 ; do
   echo "Pausing to wait for SMAPI listener"
   sleep 10
 done
-echo "SMAPI listener active, continuing..."
 sleep 3
+smcli qafl -T IBMAUTO ${smapiauth}
+if [ $? -ne 0 ]; then
+  echo "SMAPI is not operating, cannot continue"
+  exit 5
+else
+  echo "SMAPI listener active, continuing..."
+fi
 
 # Obtain the list of guests
 allguests="{{ guestnames }}"
@@ -42,7 +50,7 @@ systemctl mask ocp-guests-${othersvc}.service
 # Do this for each guest:
 for guest in ${ocpguests} ; do
   # Act on the guest
-  smcli ${operands} -H {{ ocp_smapi_host }} -U {{ ocp_smapi_user }} -P '{{ ocp_smapi_password }}'
+  smcli ${operands} ${smapiauth}
   # Nap a moment
   sleep 2
 done

--- a/local-playbooks/roles/setup-ocp-deployer/templates/ocp-dasd.sh.j2
+++ b/local-playbooks/roles/setup-ocp-deployer/templates/ocp-dasd.sh.j2
@@ -6,13 +6,21 @@
 # - Run at boot time to detect required DASD
 #
 
+smapiauth='-H {{ ocp_smapi_host }} -U {{ ocp_smapi_user }} -P {{ ocp_smapi_password }}'
+
 # pause until SMAPI is active, then a little more
 until vmcp Q VSMREQIN 2>/dev/null ; do
   echo "Pausing to wait for SMAPI listener"
   sleep 10
 done
 sleep 3
-echo "SMAPI listener active, continuing..."
+smcli qafl -T IBMAUTO ${smapiauth}
+if [ $? -ne 0 ]; then
+  echo "SMAPI is not operating, cannot continue"
+  exit 5
+else
+  echo "SMAPI listener active, continuing..."
+fi
 
 #ocpdasd={{ ocp_dasd_prefix }}
 #
@@ -62,13 +70,13 @@ IFS=" ";
 # Do this for each guest:
 for guest in ${ocpguests}; do
 #   list the existing MDISKs
-  if [ $(smcli iqd -T ${guest} -H {{ ocp_smapi_host }} -U {{ ocp_smapi_user }} -P '{{ ocp_smapi_password }}' | grep MDISK | wc -l ) = "0" ]; then
+  if [ $(smcli iqd -T ${guest} ${smapiauth} | grep MDISK | wc -l ) = "0" ]; then
 #   if none, add one:
 #     list the available volumes
-    mapfile -t dasds < <(smcli ivsqd -T {{ ocp_smapi_user }} -q 2 -e 3 -H {{ ocp_smapi_host }} -U {{ ocp_smapi_user }} -P '{{ ocp_smapi_password }}' -n LINUXEAV )
+    mapfile -t dasds < <(smcli ivsqd -T {{ ocp_smapi_user }} -q 2 -e 3 ${smapiauth} -n LINUXEAV )
 #     grab the first one from the list
     IFS=" " read -r -a dasd <<< ${dasds[0]}
 #     issue an smcli idicrd for the dasd
-    smcli idicrd -T ${guest} -a 200 -d X -t AUTOV -n ${dasd[0]} -u 1 -s ${dasd[3]} -m MR -f 1 -H {{ ocp_smapi_host }} -U {{ ocp_smapi_user }} -P '{{ ocp_smapi_password }}'
+    smcli idicrd -T ${guest} -a 200 -d X -t AUTOV -n ${dasd[0]} -u 1 -s ${dasd[3]} -m MR -f 1 ${smapiauth}
   fi
 done

--- a/local-playbooks/roles/setup-ocp-deployer/templates/ocp-retry.sh.j2
+++ b/local-playbooks/roles/setup-ocp-deployer/templates/ocp-retry.sh.j2
@@ -6,13 +6,21 @@
 # - Run when required to prepare for another build attempt
 #
 
+smapiauth='-H {{ ocp_smapi_host }} -U {{ ocp_smapi_user }} -P {{ ocp_smapi_password }}'
+
 # pause until SMAPI is active, then a little more
 until vmcp Q VSMREQIN >/dev/null 2>&1 ; do
   echo "Pausing to wait for SMAPI listener"
   sleep 10
 done
-echo "SMAPI listener active, continuing..."
 sleep 3
+smcli qafl -T IBMAUTO ${smapiauth}
+if [ $? -ne 0 ]; then
+  echo "SMAPI is not operating, cannot continue"
+  exit 5
+else
+  echo "SMAPI listener active, continuing..."
+fi
 
 # Obtain the list of guests
 ocpguests="{{ guestnames }}"
@@ -25,11 +33,11 @@ systemctl stop incrond.service
 # Do this for each guest:
 for guest in ${ocpguests} ; do
   # Shut down the guest
-  smcli id -T ${guest} -t 'WITHIN 60' -H {{ ocp_smapi_host }} -U {{ ocp_smapi_user }} -P '{{ ocp_smapi_password }}'
+  smcli id -T ${guest} -t 'WITHIN 60' ${smapiauth}
   # Nap for a moment
   sleep 2
   # Set the boot device to CMS
-  smcli iisd -T ${guest} -n CMS -H {{ ocp_smapi_host }} -U {{ ocp_smapi_user }} -P '{{ ocp_smapi_password }}'
+  smcli iisd -T ${guest} -n CMS ${smapiauth}
 done
 
 # give some time to make sure the guests are down


### PR DESCRIPTION
Add a test for functional SMAPI in places where the old "is it logged on" is present.  Also added a test to prevent breakage if we run out of disk space in icic-setup.sh.