### PR TITLE
Add nonssl.conf to Apache conf file patch

### DIFF
--- a/local-playbooks/roles/setup-firstboot-ipconf/templates/ipconf.sh.j2
+++ b/local-playbooks/roles/setup-firstboot-ipconf/templates/ipconf.sh.j2
@@ -122,7 +122,7 @@ EOF
   pushd /opt/ansible && ansible-playbook -i inventory regen-certificates.yml && popd
 
   # update Apache configuration
-  sed -i.bak -e "s/wsc.ibm/${DOMAIN}/g" -e "s/ocp-z-poc/${CLUSTER_NAME}/g" /etc/httpd/conf/httpd.conf /etc/httpd/conf.d/ssl.conf
+  sed -i.bak -e "s/wsc.ibm/${DOMAIN}/g" -e "s/ocp-z-poc/${CLUSTER_NAME}/g" /etc/httpd/conf/httpd.conf /etc/httpd/conf.d/ssl.conf /etc/httpd/conf.d/nonssl.conf
   # Hostname might have been updated, make those changes before restarting things
   if [ -z "${HOSTSET}" ]; then
     sed -i.bak "s/{{ guest_install_hostname }}/${HOSTNM}/g" /etc/httpd/conf/httpd.conf /etc/httpd/conf.d/ssl.conf


### PR DESCRIPTION
Fixes #138 by adding nonssl.conf to the list of Apache configuration files that get the hostname patched by firstboot.