### PR TITLE
Added ocp-console.html to Apache hostname patch

### DIFF
--- a/local-playbooks/roles/setup-firstboot-ipconf/templates/ipconf.sh.j2
+++ b/local-playbooks/roles/setup-firstboot-ipconf/templates/ipconf.sh.j2
@@ -122,7 +122,8 @@ EOF
   pushd /opt/ansible && ansible-playbook -i inventory regen-certificates.yml && popd
 
   # update Apache configuration
-  sed -i.bak -e "s/wsc.ibm/${DOMAIN}/g" -e "s/ocp-z-poc/${CLUSTER_NAME}/g" /etc/httpd/conf/httpd.conf /etc/httpd/conf.d/ssl.conf /etc/httpd/conf.d/nonssl.conf
+  sed -i.bak -e "s/wsc.ibm/${DOMAIN}/g" -e "s/ocp-z-poc/${CLUSTER_NAME}/g" \
+    /etc/httpd/conf/httpd.conf /etc/httpd/conf.d/ssl.conf /etc/httpd/conf.d/nonssl.conf /var/www/html/ocp-console.html
   # Hostname might have been updated, make those changes before restarting things
   if [ -z "${HOSTSET}" ]; then
     sed -i.bak "s/{{ guest_install_hostname }}/${HOSTNM}/g" /etc/httpd/conf/httpd.conf /etc/httpd/conf.d/ssl.conf


### PR DESCRIPTION
Fixed #137 by adding ocp-console.html to the list of files being patched for hostname in the firstboot script.