### PR TITLE
Add int filter to guest CPU template

### DIFF
--- a/local-playbooks/roles/setup-ocp-deployer/templates/guest.direct.j2
+++ b/local-playbooks/roles/setup-ocp-deployer/templates/guest.direct.j2
@@ -1,6 +1,6 @@
 USER {% raw %}{{ cluster_nodes[coreos_role][item].guest_name }}{% endraw %} ZVM4DEMO {% raw %}{{ guestmemory[coreos_role] }}{% endraw %}G {% raw %}{{ (guestmemory[coreos_role] | int) * 2 }}{% endraw %}G  G
  INCLUDE OCPDFLT
- COMMAND DEFINE CPU 01-{% raw %}{{ '%02X' % guestvcpus[coreos_role] }}{% endraw %} TYPE IFL
+ COMMAND DEFINE CPU 01-{% raw %}{{ '%02X' % guestvcpus[coreos_role] | int }}{% endraw %} TYPE IFL
  CPU 00
  IPL CMS
  SHARE RELATIVE {% raw %}{{ guestvcpus[coreos_role] }}{% endraw %}00


### PR DESCRIPTION
Fixes #141 by adding int filter to the template for the number of guest VCPUs being created.