### PR TITLE
Fix diskpool value for an ICIC system on SCSI

### DIFF
--- a/local-playbooks/roles/setup-icic-deployer/templates/icic-config-properties.j2
+++ b/local-playbooks/roles/setup-icic-deployer/templates/icic-config-properties.j2
@@ -1,3 +1,4 @@
+#jinja2:variable_start_string:'[%', variable_end_string:'%]', trim_blocks: False
 compute_disk_pool={{ diskpool_type }}:LINUX
 network_vswitch=icicvsw1
 compute_instance_template=ins%05x

--- a/local-playbooks/roles/setup-icic-deployer/templates/icic-config-properties.j2
+++ b/local-playbooks/roles/setup-icic-deployer/templates/icic-config-properties.j2
@@ -1,4 +1,4 @@
-compute_disk_pool=ECKD:LINUX
+compute_disk_pool={{ diskpool_type }}:LINUX
 network_vswitch=icicvsw1
 compute_instance_template=ins%05x
 compute_user_profile=icicdflt

--- a/local-playbooks/roles/setup-icic-deployer/templates/icic-setup.sh.j2
+++ b/local-playbooks/roles/setup-icic-deployer/templates/icic-setup.sh.j2
@@ -141,7 +141,7 @@ if [ "$(smcli ivsqd -T IBMAUTO -q 3 -e 3 ${smapiauth} -n LINUX  | grep 3390- | w
   mgtspace=${mgtspacefba}
   cmpspace=${cmpspacefba}
 else
-  disktype=CKD
+  disktype=ECKD
   mdsize=${mdsizeckd}
   mgtspace=${mgtspaceckd}
   cmpspace=${cmpspaceckd}
@@ -212,11 +212,12 @@ done
 
 mgtip=$(nextip ${tmpip})
 cmpip=$(nextip ${mgtip})
-echo "Telling Ansible about our IP addresses..."
+echo "Telling Ansible about our IP addresses and disk type..."
 cat >> /opt/ansible/inventory/group_vars/all/runtime.yml <<EOFYML
 #
 icic_management_ip_address: ${mgtip}
 icic_compute_ip_address: ${cmpip}
+diskpool_type: ${disktype}
 EOFYML
 
 # One at a time, we'll update the configuration of the imaged systems.  First, the management:


### PR DESCRIPTION
Fixes #158

The ICIC properties file contains the name of the DirMaint group to be used by ICIC.  It also specifies the type of disk.  I had hardcoded "ECKD" as the disk type however, which made ICIC broken on FBA.