### PR TITLE
Added SAN field to default z/VM certificates

### DIFF
--- a/local-playbooks/roles/copy-pkcs12-to-zvm/tasks/main.yml
+++ b/local-playbooks/roles/copy-pkcs12-to-zvm/tasks/main.yml
@@ -1,11 +1,14 @@
 ---
 - name: copy the package to the ELAN
   copy:
-    src: /etc/pki/tls/certs/zVM.p12
-    dest: /etc/pki/tls/certs/zVM.p12
+    src: /etc/pki/tls/certs/{{ item }}.p12
+    dest: /etc/pki/tls/certs/{{ item }}.p12
     mode: 0644
     owner: root
     group: root
+  loop:
+    - "zVM"
+    - "zVMLDAP"
 
 - name: start the FTP server on z/VM # noqa no-changed-when
   shell: /usr/local/bin/smcli ia -T FTPSERVE -H {{ smapi_host|quote }}/44444 -U {{ smapi_user|quote }} -P {{ smapi_password|quote }} && sleep 2

--- a/local-playbooks/roles/create-zvm-certificates/tasks/main.yml
+++ b/local-playbooks/roles/create-zvm-certificates/tasks/main.yml
@@ -16,6 +16,7 @@
       - keyAgreement
       - keyEncipherment
     extendedKeyUsage: ["clientAuth","serverAuth"]
+    subject_alt_name: "DNS:zVM.ibmpoc.internal,IP:{{ zvm_internal_ip_address }}"
 
 - name: generate Certificate
   openssl_certificate:
@@ -57,6 +58,7 @@
       - digitalSignature
       - keyAgreement
       - keyEncipherment
+    subject_alt_name: "DNS:LDAPSRV.ibmpoc.internal,IP:{{ zvm_internal_ip_address }}"
 
 - name: generate Certificate
   openssl_certificate:


### PR DESCRIPTION
Trying to fix #160 ... adding the IP address to the z/VM certificates, to allow any situation where the IP address is used instead of the hostname to succeed.