### PR TITLE
Enable haproxy.service

### DIFF
--- a/local-playbooks/roles/setup-firstboot-ipconf/templates/ipconf.sh.j2
+++ b/local-playbooks/roles/setup-firstboot-ipconf/templates/ipconf.sh.j2
@@ -140,6 +140,7 @@ EOF
   systemctl restart httpd.service
   echo "Apache httpd restarted"
   # restart HA-Proxy
+  systemctl enable haproxy.service
   systemctl restart haproxy.service
   echo "HA-Proxy restarted"
   ### This is the old DNS change, comment this before removal


### PR DESCRIPTION
Fixes #178 by adding `systemctl enable haproxy.service` to `ipconf.sh`.