### PR TITLE
190 ipconfsh lack of dns can impact ansible playbooks

### DIFF
--- a/local-playbooks/roles/setup-firstboot-ipconf/templates/ipconf.sh.j2
+++ b/local-playbooks/roles/setup-firstboot-ipconf/templates/ipconf.sh.j2
@@ -72,6 +72,26 @@ function changeIP {
     CLUSTER_NAME="ocp-z-poc"
   fi
 
+  # Update the /etc/resolv.conf file
+  # This relies on NetworkManager being told to disregard resolver config!
+  cat <<EOF > /etc/resolv.conf
+# /etc/resolv.conf
+# Created by zvm-ipconf service
+search ${DOMAIN} ${CLUSTER_NAME}.${DOMAIN}
+EOF
+  if [ -v DNS1 ]; then
+    echo "nameserver ${DNS1}" >> /etc/resolv.conf
+    if [ -v DNS2 ]; then
+      echo "nameserver ${DNS2}" >> /etc/resolv.conf
+    fi
+    if [ -v DNS3 ]; then
+      echo "nameserver ${DNS3}" >> /etc/resolv.conf
+    fi
+  else
+    echo "nameserver 9.9.9.9" >> /etc/resolv.conf
+    echo "nameserver 149.112.112.112" >> /etc/resolv.conf
+  fi
+
   # all the details retrieved, let's use nmcli to do the address work
   # first, obtain the UUID of the interface
   source <(grep ^UUID /etc/sysconfig/network-scripts/ifcfg-${IFN})

--- a/local-playbooks/roles/setup-firstboot-ipconf/templates/update-dns-domain.yml.j2
+++ b/local-playbooks/roles/setup-firstboot-ipconf/templates/update-dns-domain.yml.j2
@@ -41,11 +41,12 @@
       group: named
       mode: 0640
 
-  - name: Recreate resolv.conf
+  - name: Update resolv.conf
     lineinfile:
-      line: search {% raw %}{{ cluster_domain_name }}{% endraw %}{{''}}
+      line: nameserver {% raw %}{{ bastion_private_ip_address }}{% endraw %}{{''}}
       dest: /etc/resolv.conf
-      regexp: "^search .*"
+      insertbefore: "^nameserver .*"
+      firstmatch: true
 
   - name: Patch HAProxy service script
     lineinfile:


### PR DESCRIPTION
Fixes #190 

Changes the update method for DNS resolution, meaning that DNS *should* always be present even when `named-chroot` is down for update.

May need to be revisited when the Finnad action merge takes place.