### PR TITLE
Make VirtualHost for non-SSL non-host-specific

### DIFF
--- a/local-playbooks/roles/setup-web-resources/tasks/main.yml
+++ b/local-playbooks/roles/setup-web-resources/tasks/main.yml
@@ -16,7 +16,7 @@
     owner: root
     group: root
     block: |
-      <VirtualHost {{ guest_install_hostname }}.{{ cluster_domain_name }}:8080>
+      <VirtualHost *:8080>
         <Directory "/var/www/html">
           Options Indexes FollowSymLinks Includes
           XBitHack On


### PR DESCRIPTION
Fixes #193.  The previous configuration made Apache pick up the nonssl.conf settings only when the specific host name was used.  Now these settings will be picked up regardless of the name/address used to access the non-secure page(s).