### PR TITLE
Remove ocp-dasd.service startup from zvm-ipconf

### DIFF
--- a/local-playbooks/roles/setup-firstboot-ipconf/templates/ipconf.sh.j2
+++ b/local-playbooks/roles/setup-firstboot-ipconf/templates/ipconf.sh.j2
@@ -208,8 +208,6 @@ EOF
   # Start incrond
   systemctl enable --now incrond.service
 
-  # Start up the DASD configuration script because we're at a new site
-  systemctl start ocp-dasd.service
   # Prevent this service from starting next time
   systemctl disable zvm-ipconf.service
   # Announce we've finished


### PR DESCRIPTION
Fixes #224 by removing the start of `ocp-dasd.service` from `ipconf.sh`.