### PR TITLE
226 consolidated grafana loki

### DIFF
--- a/local-playbooks/roles/install-base-packages/tasks/main.yml
+++ b/local-playbooks/roles/install-base-packages/tasks/main.yml
@@ -72,7 +72,7 @@
       - unzip
       - python3
       - python3-dns
-      - python3.11-dns
+      - python3.12-dns
       - python3-libsemanage
       - incron
       - openldap-clients

--- a/local-playbooks/roles/setup-finna-response/tasks/main.yml
+++ b/local-playbooks/roles/setup-finna-response/tasks/main.yml
@@ -6,7 +6,8 @@
     mode: 0644
   loop:
   - { src: "finna-add-host.yml.j2", dest: "/opt/ansible/finna-add-host.yml" }
-  - { src: "finna-remote-dns.yml.j2", dest: "/opt/ansible/finna-remote-dns.yml" }
+  - { src: "finna-remote-elan.yml.j2", dest: "/opt/ansible/finna-remote-elan.yml" }
+  - { src: "promtail-cfg-loki-fwd.yaml.j2", dest: "/opt/ansible/templates/promtail-cfg-loki-fwd.yaml.j2" }
 
 - name: Set up the incron stuff
   block:

--- a/local-playbooks/roles/setup-finna-response/templates/finna-action.sh.j2
+++ b/local-playbooks/roles/setup-finna-response/templates/finna-action.sh.j2
@@ -12,5 +12,5 @@ fi
 # Schedule the action
 ( 
   flock 9
-  /usr/local/sbin/finna-host-add.sh $1
+  /usr/local/sbin/finna-host-add.sh $1 >> /var/log/finnad-action-$1
 ) 9>/var/run/finnad-action.lock

--- a/local-playbooks/roles/setup-finna-response/templates/finna-host-add.sh.j2
+++ b/local-playbooks/roles/setup-finna-response/templates/finna-host-add.sh.j2
@@ -8,9 +8,9 @@ SYSNAME=$1;
 # Run the playbook to add DNS records for host
 pushd /opt/ansible && ansible-playbook -i inventory -e sysname=${SYSNAME} finna-add-host.yml && popd
 
-# Is this a remote ELAN?  Push BIND updates if yes
+# Is this a remote ELAN?
 LOCALSYS=$(/usr/local/bin/finna self name)
 if [ ${SYSNAME} != ${LOCALSYS} ]; then
   MYIP=$(/usr/local/bin/finna self ip)
-  pushd /opt/ansible && ansible-playbook -i inventory -e masterip=${MYIP} finna-remote-dns.yml && popd
+  pushd /opt/ansible && ansible-playbook -i inventory -e masterip=${MYIP} -e sysname=${SYSNAME} finna-remote-elan.yml && popd
 fi

--- a/local-playbooks/roles/setup-finna-response/templates/finna-remote-elan.yml.j2
+++ b/local-playbooks/roles/setup-finna-response/templates/finna-remote-elan.yml.j2
@@ -1,0 +1,95 @@
+#jinja2:variable_start_string:'[%', variable_end_string:'%]', trim_blocks: False
+---
+- name: Playbook to push DNS and NFS reconfiguration to remote ELANs
+  hosts: s390x_remote_elans
+  handlers:
+  - name: Restart BIND named
+    systemd:
+      name: named-chroot.service
+      state: restarted
+    listen: "Restart named"
+
+  tasks:
+  - name: Update the BIND config fragments
+    template:
+      src: named/slavezone.conf.j2
+      dest: /etc/named/{{ item }}.conf
+      group: named
+      mode: 0640
+    vars:
+      domain_name: "{{ item }}"
+    loop:
+      - "{{ zvmesi_domain_name }}"
+      - "{{ esigroup | lower }}.zvmesi"
+    notify:
+      - "Restart named"
+  - name: Get the coordinator IP address
+    shell:
+      cmd: finna coord ip
+    register: coord_ip
+  - name: Add the NFS mount for ESI content
+    mount:
+      src: "{{ coord_ip.stdout }}:/opt/content"
+      path: /opt/content
+      opts: rw,sync,hard
+      state: mounted
+      fstype: nfs
+  - name: Add config file for Loki forwarder
+    template:
+      src: promtail-cfg-loki-fwd.yaml.j2
+      dest: /etc/loki/promtail-loki-fwd.yaml
+      mode: 0644
+      owner: root
+      group: root
+  - name: Disable Loki and Grafana on this host
+    systemd:
+      name: "{{ item }}"
+      state: stopped
+      enabled: false
+    loop:
+      - loki
+      - grafana
+  - name: Remove loki.service dependency from promtail@ unit
+    replace:
+      path: /usr/local/lib/systemd/system/promtail@.service
+      regexp: '(\s+)loki\.service(\s+)?$'
+      replace: '\1promtail-loki-fwd.service\2'
+      backup: yes
+  - name: Create promtail-loki-fwd.service
+    copy:
+      dest: /usr/local/lib/systemd/system/promtail-loki-fwd.service
+      content: |
+        [Unit]
+        Description=Promtail service for loki-push-api forwarder
+        Requires=network-online.target
+        After=network-online.target named-chroot.service
+        [Service]
+        Type=exec
+        Environment="HOSTNAME=%H"
+        ExecStart=/usr/local/bin/promtail -log.level=error -config.file=/etc/loki/promtail-loki-fwd.yaml -client.external-labels=hostname=${HOSTNAME}
+        RemainAfterExit=false
+        StandardOutput=journal
+        [Install]
+        WantedBy=default.target
+      mode: 0644
+      owner: root
+      group: root
+  - name: Start the Loki push API forwarder
+    systemd:
+      name: promtail-loki-fwd
+      state: started
+      enabled: true
+      daemon-reload: true
+  - name: Restart the other Promtail instances
+    systemd:
+      name: "promtail@{{ item }}"
+      state: restarted
+      enabled: true
+    loop:
+      - httpd
+      - icicbuild
+      - journal
+      - phpfpm
+      - squid
+      - syslog
+      - varlog

--- a/local-playbooks/roles/setup-finna-response/templates/promtail-cfg-loki-fwd.yaml.j2
+++ b/local-playbooks/roles/setup-finna-response/templates/promtail-cfg-loki-fwd.yaml.j2
@@ -1,0 +1,17 @@
+#jinja2:variable_start_string:'[%', variable_end_string:'%]', trim_blocks: False
+server:
+  http_listen_port: 0
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions_loki-fwd.yaml
+
+clients:
+  - url: http://{{ masterip }}:3100/loki/api/v1/push
+
+scrape_configs:
+- job_name: "push-{{ sysname | lower }}"
+  loki_push_api:
+    server:
+      http_listen_port: 3100
+      grpc_listen_port: 0

--- a/local-playbooks/roles/setup-firstboot-ipconf/templates/haproxy/haproxy.cfg.j2
+++ b/local-playbooks/roles/setup-firstboot-ipconf/templates/haproxy/haproxy.cfg.j2
@@ -5,7 +5,7 @@
 
 
 global
-    log         127.0.0.1 local2
+    log         {{ bastion_public_ip_address }} local2
     chroot      /var/lib/haproxy
     pidfile     /var/run/haproxy.pid
     maxconn     4000

--- a/local-playbooks/roles/setup-firstboot-ipconf/templates/ipconf.sh.j2
+++ b/local-playbooks/roles/setup-firstboot-ipconf/templates/ipconf.sh.j2
@@ -106,6 +106,7 @@ EOF
 
   # Update the system hostname
   FULLDOMAIN="${ESIGROUP,,}.${DOMAIN}"
+  echo "${IPADDR}  ${HOSTNM}.${FULLDOMAIN} ${HOSTNM}" >> /etc/hosts
   echo "${HOSTNM}.${FULLDOMAIN}" > /etc/hostname
   hostname -F /etc/hostname
   echo "System hostname updated to $(hostname)"
@@ -178,18 +179,26 @@ EOF
   systemctl enable grafana-server.service
   systemctl restart grafana-server.service
   echo "Grafana restarted"
-  # restart Mosquitto
-  systemctl enable mosquitto.service
-  systemctl restart mosquitto.service
-  echo "Mosquitto restarted"
+  # not using Mosquitto for now
+  systemctl disable mosquitto.service
+  systemctl stop mosquitto.service
+  echo "Mosquitto disabled"
   # restart Loki
   systemctl enable loki.service
   systemctl restart loki.service
   echo "Loki restarted"
-  # restart Promtail
-  systemctl enable promtail-mqtt.service
-  systemctl restart promtail-mqtt.service
-  echo "Promtail restarted"
+  # not using the MQTT Promtail for now
+  systemctl disable promtail-mqtt.service
+  systemctl stop promtail-mqtt.service
+  echo "promtail-mqtt disabled"
+  # restart the remaining Promtails
+  for prom in httpd icicbuild journal phpfpm squid syslog varlog; do
+    systemctl restart promtail@${prom}
+  done
+  echo "Restarted general Promtails"
+  # restart rsyslogd
+  systemctl restart rsyslog.service
+  echo "Rsyslog restarted"
 
   ### This is the old DNS change, comment this before removal
 #  # upstream DNS is harder, have to change the bind config...

--- a/local-playbooks/roles/setup-grafana-log-viewer/files/dashboard-logs.json
+++ b/local-playbooks/roles/setup-grafana-log-viewer/files/dashboard-logs.json
@@ -102,7 +102,7 @@
               "uid": "elanLoki"
             },
             "editorMode": "builder",
-            "expr": "{application=\"VMCONS\", zvm_guest=~\"${guestname}\"} |= `` | line_format \"{{ .zvm_guest }} {{__line__}}\"",
+            "expr": "{application=\"VMCONS\", zvm_guest=~\"${guestname}\", zvm_name=~\"${sysname}\"} |= `` | line_format \"{{ .zvm_guest }} {{__line__}}\"",
             "queryType": "range",
             "refId": "A"
           }
@@ -153,7 +153,7 @@
               "uid": "elanLoki"
             },
             "editorMode": "builder",
-            "expr": "{application=\"VMEVENT\", zvm_guest=~\"${guestname}\"} |= ``",
+            "expr": "{application=\"VMEVENT\", zvm_guest=~\"${guestname}\", zvm_name=~\"${sysname}\"} |= ``",
             "queryType": "range",
             "refId": "A"
           }
@@ -168,6 +168,35 @@
     "tags": [],
     "templating": {
       "list": [
+        {
+          "current": {
+            "selected": false,
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": {
+            "type": "loki",
+            "uid": "elanLoki"
+          },
+          "definition": "",
+          "description": "Filter on z/VM system name",
+          "hide": 0,
+          "includeAll": true,
+          "label": "z/VM system name",
+          "multi": true,
+          "name": "sysname",
+          "options": [],
+          "query": {
+            "label": "zvm_name",
+            "refId": "LokiVariableQueryEditor-VariableQuery",
+            "stream": "",
+            "type": 1
+          },
+          "refresh": 2,
+          "skipUrlSync": false,
+          "sort": 0,
+          "type": "query"
+        },
         {
           "current": {
             "selected": false,

--- a/local-playbooks/roles/setup-grafana-log-viewer/files/promtail-cfg-syslog.yaml
+++ b/local-playbooks/roles/setup-grafana-log-viewer/files/promtail-cfg-syslog.yaml
@@ -12,7 +12,7 @@ scrape_configs:
   - job_name: syslog
     syslog:
       listen_address: 127.0.0.1:20514
-      label_structured_data: false
+      label_structured_data: true
       labels:
         job: syslog
       use_incoming_timestamp: true
@@ -26,6 +26,8 @@ scrape_configs:
         target_label: application
       - source_labels: [__syslog_message_facility]
         target_label: facility
+      - source_labels: [__syslog_message_sd_zVMESI_2_zvmname]
+        target_label: zvm_name
     pipeline_stages:
     - match:
         pipeline_name: vmcons

--- a/local-playbooks/roles/setup-grafana-log-viewer/files/promtail.service
+++ b/local-playbooks/roles/setup-grafana-log-viewer/files/promtail.service
@@ -4,7 +4,8 @@ Requires=network-online.target loki.service
 After=network-online.target named-chroot.service loki.service
 [Service]
 Type=exec
-ExecStart=/usr/local/bin/promtail -log.level=error -config.file=/etc/loki/promtail-%i.yaml
+Environment="HOSTNAME=%H"
+ExecStart=/usr/local/bin/promtail -log.level=error -config.file=/etc/loki/promtail-%i.yaml -client.external-labels=hostname=${HOSTNAME}
 RemainAfterExit=false
 StandardOutput=journal
 [Install]

--- a/local-playbooks/roles/setup-grafana-log-viewer/tasks/main.yml
+++ b/local-playbooks/roles/setup-grafana-log-viewer/tasks/main.yml
@@ -8,36 +8,6 @@
   - mosquitto
   - elan-loki
 
-- name: Create basic grafana.ini
-  copy:
-    content: |
-      [server]
-      http_addr =
-      http_port = 3000
-      domain = {{ cluster_base_domain }}
-      root_url = http://{{ bastion_public_ip_address }}:3000/
-      enforce_domain = False
-      protocol = http
-      ; serve_from_sub_path = true
-
-      [paths]
-      provisioning = /etc/grafana/provisioning
-
-      [security]
-      allow_embedding = true
-
-      [dashboards]
-      min_refresh_interval = 1s
-
-      [plugins]
-      allow_loading_unsigned_plugins = performancecopilot-pcp-app,pcp-redis-datasource,pcp-vector-datasource,pcp-bpftrace-datasource,pcp-flamegraph-panel,pcp-breadcrumbs-panel,pcp-troubleshooting-panel,performancecopilot-redis-datasource,performancecopilot-vector-datasource,performancecopilot-bpftrace-datasource,performancecopilot-flamegraph-panel,performancecopilot-breadcrumbs-panel,performancecopilot-troubleshooting-panel
-
-      [feature_toggles]
-      publicDashboards = true
-    dest: /etc/grafana/grafana.ini
-    owner: grafana
-    mode: 0644
-
 - name: Allow traffic at port 1883 for Mosquitto
   firewalld:
     port: 1883/tcp
@@ -63,6 +33,14 @@
     owner: mosquitto
     group: mosquitto
     backup: yes
+
+- name: Configure Grafana
+  template:
+    src: grafana.ini.j2
+    dest: /etc/grafana/grafana.ini
+    mode: 0644
+    owner: grafana
+    group: grafana
 
 - name: Create provisioning file for Loki datasource
   copy:
@@ -192,6 +170,16 @@
 - name: Configure firewalld for syslog
   firewalld:
     service: syslog
+    state: enabled
+    permanent: true
+    immediate: true
+    zone: "{{ item }}"
+  loop:
+    - internal
+    - public
+- name: Configure firewalld for Loki
+  firewalld:
+    port: 3100/tcp
     state: enabled
     permanent: true
     immediate: true

--- a/local-playbooks/roles/setup-grafana-log-viewer/templates/grafana.ini.j2
+++ b/local-playbooks/roles/setup-grafana-log-viewer/templates/grafana.ini.j2
@@ -1,0 +1,24 @@
+[server]
+http_addr =
+http_port = 3000
+domain = {{ cluster_base_domain }}
+root_url = https://{{ guest_install_hostname }}.{{ cluster_base_domain | lower }}/grafana
+enforce_domain = False
+protocol = http
+serve_from_sub_path = true
+
+[paths]
+provisioning = /etc/grafana/provisioning
+
+[security]
+allow_embedding = true
+csrf_trusted_origins = {{ guest_install_hostname }}.{{ cluster_base_domain | lower }}
+
+[dashboards]
+min_refresh_interval = 1s
+
+[plugins]
+allow_loading_unsigned_plugins = performancecopilot-pcp-app,pcp-redis-datasource,pcp-vector-datasource,pcp-bpftrace-datasource,pcp-flamegraph-panel,pcp-breadcrumbs-panel,pcp-troubleshooting-panel,performancecopilot-redis-datasource,performancecopilot-vector-datasource,performancecopilot-bpftrace-datasource,performancecopilot-flamegraph-panel,performancecopilot-breadcrumbs-panel,performancecopilot-troubleshooting-panel
+
+[feature_toggles]
+publicDashboards = true


### PR DESCRIPTION
Fixes #226 by adding support to the Loki configuration to send log data from additional ELANs to the Loki on the coordinator.

The main change is the automation in finna-action, which changes the setup on the remote ELAN to disable Loki and replace it with a Promtail instance configured with `loki_push_api`.  In addition to this, miscellaneous other updates add support for forwarding messages with a `hostname` label set appropriately (prior support already set the `zvm_name` label for messages such as VMEVENT and console that originate from z/VM).