### PR TITLE
Fixes #189 - enable named-chroot

### DIFF
--- a/local-playbooks/roles/setup-firstboot-ipconf/templates/ipconf.sh.j2
+++ b/local-playbooks/roles/setup-firstboot-ipconf/templates/ipconf.sh.j2
@@ -137,8 +137,9 @@ EOF
 #  sed -i.bak '/bastion_public_ip_address/c \bastion_public_ip_address: '\"${IPADDR}\" /opt/ansible/inventory/group_vars/all.yml
   # Run Ansible playbook to update the BIND configuration
   (cd /opt/ansible && ansible-playbook -i inventory update-dns-domain.yml)
-  # start named
+  # start and enable named
   systemctl start named-chroot.service
+  systemctl enable named-chroot.service
 
   # Regenerate all the certificates
   (cd /opt/ansible && ansible-playbook -i inventory regen-certificates.yml)


### PR DESCRIPTION
As per title: fixes #189 by adding an enable for `named-chroot.service`.  This was the only service not found to be enabled/started.