### PR TITLE
Fixed (removed) quotes in SMAPI invocation

### DIFF
--- a/local-playbooks/roles/setup-icic-deployer/templates/icic-setup.sh.j2
+++ b/local-playbooks/roles/setup-icic-deployer/templates/icic-setup.sh.j2
@@ -350,7 +350,7 @@ echo "${cmpip} ${iciccmp,,}.${DOMAIN} ${iciccmp,,}" >> /etc/hosts
 
 # IPLing the management guest
 echo "Issuing a SMAPI IPL for the management guest..."
-smcli ia -T "${icicmgt}" "${smapiauth}"
+smcli ia -T ${icicmgt} ${smapiauth}
 sleep 1
 echo "Starting the Ansible configuration of management guest..."
 cd /opt/ansible && ansible-playbook -i inventory -v setup-icic-management.yml


### PR DESCRIPTION
Fixed #236 by removing quotes from around `${smapiauth}`.  Strings should usually be quoted to prevent the contents from being expanded, but expansion is exactly what we need in this case.