### PR TITLE
Restricted matching of FilesMatch regex

### DIFF
--- a/local-playbooks/roles/setup-web-resources/tasks/main.yml
+++ b/local-playbooks/roles/setup-web-resources/tasks/main.yml
@@ -52,7 +52,7 @@
           <FilesMatch ".*\.php$">
             Require all denied
           </FilesMatch>
-          <FilesMatch "(s_|ocp-|start).*$">
+          <FilesMatch "^(s_|ocp-|start).*html$">
             Require all denied
           </FilesMatch>
           ErrorDocument 403 /error.html


### PR DESCRIPTION
Suppression of files by name in the HTTP (non-secure) Apache configuration was too greedy and prevented a RHEL install.  Made the regex more choosy.