### PR TITLE
245 dashboard metric dials got broken

### DIFF
--- a/local-playbooks/roles/setup-web-resources/tasks/main.yml
+++ b/local-playbooks/roles/setup-web-resources/tasks/main.yml
@@ -108,12 +108,14 @@
       # Reverse-proxy configuration for cross-system stats
       ProxyPassMatch "^/zvmstats-(.*).json$" "https://$1:8443/zvmstats.json"
       RewriteEngine On
+      <Location "/grafana/">
+        ProxyPreserveHost On
+      </Location>
       RewriteCond %{HTTP:Upgrade} websocket [NC]
       RewriteCond %{HTTP:Connection} upgrade [NC]
       RewriteRule ^/grafana/?(.*) "ws://127.0.0.1:3000/grafana/$1" [P,L]
       ProxyPassMatch "^/grafana/(.*)$" "http://localhost:3000/grafana/$1"
       ProxyPassReverse "/grafana/" "http://localhost:3000/grafana/"
-      ProxyPreserveHost On
 
 - name: Download and unwind LDAP tools
   block:


### PR DESCRIPTION
Fixes #245 by moving the `ProxyPreserveHost On` setting needed for Grafana into a Location just for Grafana.